### PR TITLE
Highwatermark won't refill the whole buffer

### DIFF
--- a/throughs.js
+++ b/throughs.js
@@ -282,7 +282,7 @@ function (read, highWaterMark) {
       ending = ending || end
       if(data != null) buffer.push(data)
 
-      next(); readAhead()
+      readAhead(); next()
     })
   }
 
@@ -292,7 +292,7 @@ function (read, highWaterMark) {
     ended = ended || end
     waiting.push(cb)
 
-    next(); readAhead()
+    readAhead(); next()
   }
 }
 


### PR DESCRIPTION
What happens is that highWaterMark first will fill the buffer and then will drain it.
The problem is that because it reads first, and drains second it's length will always be
`highWaterMark - 1`. The only exception is the first read, where it fills the buffer completely,
because it doesn't drain.

The way I fixed it, is simply by changing the order. It will release buffer first, and refill it second.

Here is a code that proves it:

``` js
var pull = require("pull-stream");

var delayedMap = function(d, done) {
  setTimeout( function () {
    done (null, d);
  }, 1000)
}

pull(
  pull.count(10),
  pull.asyncMap(delayedMap),
  pull.highWaterMark(1),
  pull.asyncMap(delayedMap),
  pull.log()
)

// Just to mark us when a second is being passed
setInterval( function () {
  console.log("second")
}, 1000)
```

Here is the output before the fix:

```
second
0
second
second
1
second
second
2
second
second
3
second
second
4
second
second
5
second
second
6
second
second
7
second
second
8
second
second
9
second
second
10
```

You can see that except of the first read, it waits 2 seconds between the reads.

Here is how it looks with the patch:

```
second
0
second
1
second
2
second
3
second
4
second
5
second
6
second
7
second
8
second
9
second
10
```

As you can see, one second between the reads.
