### PR TITLE
Partial sink pipelines should do something sensible with multiple calls

### DIFF
--- a/pull.js
+++ b/pull.js
@@ -7,8 +7,25 @@ module.exports = function pull (a) {
     for(var i = 0; i < length; i++)
       args[i] = arguments[i]
     return function (read) {
-      args.unshift(read)
-      return pull.apply(null, args)
+      if (args == null) {
+        throw new TypeError("partial sink should only be called once!")
+      }
+
+      // Grab the reference after the check, because it's always an array now
+      // (engines like that kind of consistency).
+      var ref = args
+      args = null
+
+      // Prioritize common case of small number of pulls.
+      switch (length) {
+      case 1: return pull(read, ref[0])
+      case 2: return pull(read, ref[0], ref[1])
+      case 3: return pull(read, ref[0], ref[1], ref[2])
+      case 4: return pull(read, ref[0], ref[1], ref[2], ref[3])
+      default:
+        ref.unshift(read)
+        return pull.apply(null, ref)
+      }
     }
   }
 
@@ -30,8 +47,3 @@ module.exports = function pull (a) {
 
   return read
 }
-
-
-
-
-

--- a/test/pull.js
+++ b/test/pull.js
@@ -4,8 +4,7 @@ function curry (fun) {
   return function () {
     var args = [].slice.call(arguments)
     return function (read) {
-      args.unshift(read)
-      return fun.apply(null, args)
+      return fun.apply(null, [read].concat(args))
     }
   }
 }
@@ -95,3 +94,20 @@ tape('turn pull(through,...) -> Through', function (t) {
 //  )
 //
 
+tape("writable pull() should throw when called twice", function (t) {
+  t.plan(2)
+
+  var stream = pull(
+    map(function (e) { return e*e }),
+    sum(function (err, value) {
+      console.log(value)
+      t.equal(value, 385)
+    })
+  )
+
+  stream(values([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+
+  t.throws(function () {
+    stream(values([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+  }, TypeError)
+})


### PR DESCRIPTION
The extra work is necessary to avoid keeping garbage lying around. I did make an effort to avoid an extra array allocation for the common case of smaller partial pipelines (5 or less in the chain), though.