### PR TITLE
perf: don't access array out of bounds in pull.values

### DIFF
--- a/sources/values.js
+++ b/sources/values.js
@@ -15,7 +15,9 @@ module.exports = function values (array, onAbort) {
   return function (abort, cb) {
     if(abort)
       return abortCb(cb, abort, onAbort)
-    cb(i >= array.length || null, array[i++])
+    if(i >= array.length)
+      cb(true)
+    else
+      cb(null, array[i++])
   }
 }
-


### PR DESCRIPTION
I was going through the code using [IR Hydra](http://mrale.ph/irhydra/2) and found this simple to remove v8 deoptimization due to an out of bounds access of an array in `pull.values`.

Ran the bechmark with the following result.

|                    | `master`    | `perf-values` |
|--------------------|-------------|-------------|
|pull3*100000        | 1160.586ms  | 1121.529ms  |
|                    | 1179.353ms  | 1143.588ms  |
|                    | 1150.296ms  | 1195.693ms  |
|pull_compose*100000 | 1202.526ms  | 1155.243ms  |  
|                    | 1187.414ms  | 1159.004ms  |
|                    | 1201.530ms  | 1174.030ms  |
| pull_chain*100000  | 1180.148ms  | 1097.641ms  |
|                    | 1120.561ms  | 1098.460ms  |
|                    | 1163.785ms  | 1114.046ms  |


