### PR TITLE
Drain(eachFn, cb) should be cb(err) never cb(true)

### DIFF
--- a/test/drain-abort.js
+++ b/test/drain-abort.js
@@ -29,7 +29,8 @@ tape('abort on drain - async', function (t) {
   var drain = pull.drain(function () {
     if(c < 0) throw new Error('stream should have aborted')
     if(!--c) return drain.abort()
-  }, function () {
+  }, function (err) {
+    t.equal(err, null)
     t.end()
   })
 
@@ -43,7 +44,8 @@ tape('abort on drain - sync', function (t) {
   var drain = pull.drain(function () {
     if(c < 0) throw new Error('stream should have aborted')
     if(!--c) return drain.abort()
-  }, function () {
+  }, function (err) {
+    t.equal(err, null)
     t.end()
   })
 
@@ -70,6 +72,7 @@ tape('abort on drain - async, out of cb', function (t) {
   }, 100)
 
 })
+
 
 
 

--- a/test/drain-abort.js
+++ b/test/drain-abort.js
@@ -74,7 +74,42 @@ tape('abort on drain - async, out of cb', function (t) {
 })
 
 
+tape('abort while inside op', function (t) {
 
+  var n = 0
+  var drain
+  pull(
+    pull.values([1,2,3,4,5]),
+    drain = pull.drain(function (n) {
+      t.equal(n, 1)
+      drain.abort(function (err) {
+        t.notOk(err)
+      })
+    }, function (err) {
+      t.equal(err, null)
+      t.end()
 
+    })
+  )
+})
 
+tape('abort while inside op AND return false', function (t) {
+
+  var n = 0
+  var drain
+  pull(
+    pull.values([1,2,3,4,5]),
+    drain = pull.drain(function (n) {
+      t.equal(n, 1)
+      drain.abort(function (err) {
+        t.notOk(err)
+      })
+      return false
+    }, function (err) {
+      t.equal(err, null)
+      t.end()
+
+    })
+  )
+})
 


### PR DESCRIPTION
the second argument to drain is intended to be a regular node callback. it should inform you when the stream is over by being called. with an error argument if there was an error.

I realized that when it is aborted, it was calling back with `cb(true)` this was never my intention, but I realized that there was no test coverage for this. The test now check this. I also thought of a slim edgecase around if you call `sink.abort` _AND_ return false (which indicates abort from inside `eachFn`

I'm not entirely sure that there isn't something else that depends on this. I grepped my dev directory for things this may effect, but did not find much that used this actually! (most of my pull-stream modules are throughs, anyway)
This could effect a module that is using Drain inside of a read function...
I'm pretty sure that this is gonna be safe to merge, but would like to hear from others who may be effected

@ahdinosaur @yoshuawuyts @DamonOehlman @clehner 
