### PR TITLE
make initial reduce() accumulator value optional

### DIFF
--- a/sinks/reduce.js
+++ b/sinks/reduce.js
@@ -2,11 +2,31 @@
 
 var drain = require('./drain')
 
-module.exports = function reduce (reducer, acc, cb) {
-  return drain(function (data) {
-    acc = reducer(acc, data)
-  }, function (err) {
-    cb(err, acc)
-  })
+module.exports = function reduce (/* reducer, acc, cb */) {
+  var reducer = arguments[0]
+  var acc
+  var cb
+  if (arguments.length === 3) {
+    acc = arguments[1]
+    cb = arguments[2]
+    return drain(function (data) {
+      acc = reducer(acc, data)
+    }, function (err) {
+      cb(err, acc)
+    })
+  } else {
+    cb = arguments[1]
+    var first = true
+    return drain(function (data) {
+      if (first) {
+        acc = data
+        first = false
+      } else {
+        acc = reducer(acc, data)
+      }
+    }, function (err) {
+      cb(err, acc)
+    })
+  }
 }
 

--- a/test/drain-if.js
+++ b/test/drain-if.js
@@ -12,6 +12,16 @@ test('reduce becomes through', function (t) {
   )
 })
 
+test('reduce without initial value', function (t) {
+  pull(
+    pull.values([1,2,3]),
+    pull.reduce(function (a, b) {return a + b}, function (err, val) {
+      t.equal(val, 6)
+      t.end()
+    })
+  )
+})
+
 
 test('reduce becomes drain', function (t) {
   pull(


### PR DESCRIPTION
This small PR helps `reduce()` better emulate `Array.prototype.reduce` and friends by making the initial accumulator value argument optional.  If the callee does not pass such a value, the reduction starts with the first streamed value.
