### PR TITLE
add async variant of values

### DIFF
--- a/sources/async-values.js
+++ b/sources/async-values.js
@@ -1,0 +1,24 @@
+'use strict'
+var abortCb = require('../util/abort-cb')
+
+module.exports = function asyncValues (generator, onAbort) {
+  var i = 0
+  var array
+  return function self (abort, cb) {
+    if(abort) return abortCb(cb, abort, onAbort)
+    else if(!array) {
+      generator(function (err, yielded) {
+        if(err) return cb(err)
+        else {
+          array = Array.isArray(yielded)
+            ? yielded
+            : Object.keys(yielded).map(function (k) {
+              return yielded[k]
+            })
+          self(abort, cb)
+        }
+      })
+    } else if(i >= array.length) cb(true)
+    else cb(null, array[i++])
+  }
+}

--- a/sources/index.js
+++ b/sources/index.js
@@ -3,6 +3,7 @@ module.exports = {
   keys: require('./keys'),
   once: require('./once'),
   values: require('./values'),
+  asyncValues: require('./async-values'),
   count: require('./count'),
   infinite: require('./infinite'),
   empty: require('./empty'),

--- a/test/values.js
+++ b/test/values.js
@@ -14,9 +14,36 @@ tape('values - array', function (t) {
   )
 })
 
+tape('asyncValues - array', function (t) {
+  pull(
+    pull.asyncValues(function (cb) {
+      cb(null, [1,2,3])
+    }),
+    pull.collect(function (err, ary) {
+      t.notOk(err)
+      t.deepEqual(ary, [1, 2, 3])
+      t.end()
+    })
+  )
+})
+
 tape('values - object', function (t) {
   pull(
     pull.values({a:1,b:2,c:3}),
+    pull.collect(function (err, ary) {
+      t.notOk(err)
+      t.deepEqual(ary, [1, 2, 3])
+      t.end()
+    })
+  )
+
+})
+
+tape('asyncValues - object', function (t) {
+  pull(
+    pull.asyncValues(function (cb) {
+      cb(null, {a:1,b:2,c:3})
+    }),
     pull.collect(function (err, ary) {
       t.notOk(err)
       t.deepEqual(ary, [1, 2, 3])
@@ -35,6 +62,31 @@ tape('values, abort', function (t) {
   var read = pull.values([1,2,3], function (err) {
     t.end()
   })
+
+  read(null, function (_, one) {
+    t.notOk(_)
+    t.equal(one, 1)
+    read(err, function (_err) {
+      t.equal(_err, err)
+    })
+  })
+
+})
+
+tape('asyncValues, abort', function (t) {
+
+  t.plan(3)
+
+  var err = new Error('intentional')
+
+  var read = pull.asyncValues(
+    function (cb) {
+      cb(null, [1,2,3]),
+      function (err) {
+        t.end()
+      }
+    }
+  )
 
   read(null, function (_, one) {
     t.notOk(_)


### PR DESCRIPTION
This PR adds a variant of `pull.values` that takes an async function that calls back with an array.
