### PR TITLE
reduce with initial value

### DIFF
--- a/sinks/reduce.js
+++ b/sinks/reduce.js
@@ -2,11 +2,31 @@
 
 var drain = require('./drain')
 
-module.exports = function reduce (reducer, acc, cb) {
-  return drain(function (data) {
-    acc = reducer(acc, data)
-  }, function (err) {
-    cb(err, acc)
-  })
+module.exports = function reduce (/* reducer, acc, cb */) {
+  var reducer = arguments[0]
+  var acc
+  var cb
+  if (arguments.length === 3) {
+    acc = arguments[1]
+    cb = arguments[2]
+    return drain(function (data) {
+      acc = reducer(acc, data)
+    }, function (err) {
+      cb(err, acc)
+    })
+  } else {
+    cb = arguments[1]
+    var first = true
+    return drain(function (data) {
+      if (first) {
+        acc = data
+        first = false
+      } else {
+        acc = reducer(acc, data)
+      }
+    }, function (err) {
+      cb(err, acc)
+    })
+  }
 }
 

--- a/sinks/reduce.js
+++ b/sinks/reduce.js
@@ -6,27 +6,23 @@ module.exports = function reduce (/* reducer, acc, cb */) {
   var reducer = arguments[0]
   var acc
   var cb
-  if (arguments.length === 3) {
+  var sink = drain(function (data) {
+    acc = reducer(acc, data)
+  }, function (err) {
+    cb(err, acc)
+  })
+  if (arguments.length === 2) {
+    cb = arguments[2]
+    return function (source) {
+      source(null, function (end, data) {
+        //if ended immediately, and no initial...
+        if(end) return cb(end === true ? null : end)
+        acc = data; sink(source)
+      })
+    }
+  } else {
     acc = arguments[1]
     cb = arguments[2]
-    return drain(function (data) {
-      acc = reducer(acc, data)
-    }, function (err) {
-      cb(err, acc)
-    })
-  } else {
-    cb = arguments[1]
-    var first = true
-    return drain(function (data) {
-      if (first) {
-        acc = data
-        first = false
-      } else {
-        acc = reducer(acc, data)
-      }
-    }, function (err) {
-      cb(err, acc)
-    })
+    return sink
   }
 }
-

--- a/sinks/reduce.js
+++ b/sinks/reduce.js
@@ -2,17 +2,14 @@
 
 var drain = require('./drain')
 
-module.exports = function reduce (/* reducer, acc, cb */) {
-  var reducer = arguments[0]
-  var acc
-  var cb
+module.exports = function reduce (reducer, acc, cb ) {
+  if(!cb) cb = acc, acc = null
   var sink = drain(function (data) {
     acc = reducer(acc, data)
   }, function (err) {
     cb(err, acc)
   })
-  if (arguments.length === 2) {
-    cb = arguments[2]
+  if (arguments.length === 2)
     return function (source) {
       source(null, function (end, data) {
         //if ended immediately, and no initial...
@@ -20,9 +17,6 @@ module.exports = function reduce (/* reducer, acc, cb */) {
         acc = data; sink(source)
       })
     }
-  } else {
-    acc = arguments[1]
-    cb = arguments[2]
+  else
     return sink
-  }
 }

--- a/test/drain-if.js
+++ b/test/drain-if.js
@@ -12,6 +12,16 @@ test('reduce becomes through', function (t) {
   )
 })
 
+test('reduce without initial value', function (t) {
+  pull(
+    pull.values([1,2,3]),
+    pull.reduce(function (a, b) {return a + b}, function (err, val) {
+      t.equal(val, 6)
+      t.end()
+    })
+  )
+})
+
 
 test('reduce becomes drain', function (t) {
   pull(


### PR DESCRIPTION
I was about to merge @kemitchell's pr https://github.com/pull-stream/pull-stream/pull/77
but it was bugging me that there where two completely separate code paths, and that it added trippled the number of lines.

This takes a different style, the main thing, is that if acc is not provided, it treats the first item as a special case, then falls back to the main way. I feel that this is more _the pull-stream way_

I also changed the way variable arguments where handled, there are lots of ways to do this... This is just the way that I always do it, [which i learned from isaacs back in the day, eg](https://github.com/npm/npm/blob/162166c96bbb8ce3d8ea9c5424c2c2a924c84679/lib/bundle.js#L37)
