### PR TITLE
Test and document continuables

### DIFF
--- a/docs/pull.md
+++ b/docs/pull.md
@@ -72,6 +72,43 @@ pull(a, b, a)
 //"pull from a to b and then back to a"
 ```
 
+## Continuable
+
+[Continuables](https://github.com/Raynos/continuable) let you defer a stream and handle the completion of the sink stream.  For example:
+
+```js
+var cont = pull(...streams, sink)
+
+// ...
+
+cont(function (err) {
+  // stream finished
+})
+```
+
+Or call beside it if you are not deferring:
+
+```js
+pull(...streams, sink)(function (err) {
+  // stream finished
+})
+```
+
+They are created by making a sink stream return a continuable, which uses it's callback and reads:
+
+```js
+function sink (read) {
+  return function continuable (done) {
+    // Do reads and eventually call `done`
+    read(null, function (end, data) {
+      if (end === true) return done(null)
+      if (end) return done(end)
+      // ... otherwise use `data`
+    })
+  }
+}
+```
+
 ## API
 
 ```js

--- a/test/continuable.js
+++ b/test/continuable.js
@@ -1,0 +1,38 @@
+var pull = require('../pull')
+var count = require('../sources/count')
+var error = require('../sources/error')
+var map = require('../throughs/map')
+var test = require('tape')
+
+test('continuable stream', function (t) {
+  t.plan(2)
+
+  var continuable = function (read) {
+    return function (cb) {
+      read(null, function  next (end, data) {
+        if (end === true) return cb(null)
+        if (end) return cb(end)
+        read(end, next)
+      })
+    }
+  }
+
+  // With values:
+  pull(
+    count(5),
+    map(function (item) {
+      return item * 2
+    }),
+    continuable
+  )(function (err) {
+    t.false(err, 'no error')
+  })
+
+  // With error:
+  pull(
+    error(new Error('test error')),
+    continuable
+  )(function (err) {
+    t.is(err.message, 'test error', 'error')
+  })
+})


### PR DESCRIPTION
This is small PR to just test and document behavior of continuables.

But I was wondering, was the plan in #87 to have continuables replace `onEnd` parameters?  Because I think that is what I want.