### PR TITLE
fix asyncMap: abortCb is not a function

### DIFF
--- a/throughs/async-map.js
+++ b/throughs/async-map.js
@@ -33,7 +33,7 @@ module.exports = function asyncMap (map) {
               busy = false
               if(aborted) {
                 cb(aborted)
-                abortCb(aborted)
+                abortCb && abortCb(aborted)
               }
               else if(err) next (err, cb)
               else cb(null, data)


### PR DESCRIPTION
I experienced the error `abortCb is not a function` thrown from asyncMap while developing a scuttlebutt mobile app, and I took a look at the asyncMap source code, and `abortCb` is initially undefined. It seemed like I hit a corner case where the variable was still undefined but was called.

Initially I just fixed the source code by adding `abortCb &&`, but I also wanted to add a test. The test is simple enough, and shows that the use case which triggers the crash is when the readable stream is slow to acknowledge the abort request from the sink.