### PR TITLE
Make errors thrown during filter end the stream

### DIFF
--- a/test/filter.js
+++ b/test/filter.js
@@ -59,3 +59,17 @@ test('inverse filter with regexp', function (t) {
   )
 })
 
+test('errors thrown in filters should end the stream', function (t) {
+  const error = new Error('Abort!')
+
+  pull(
+    pull.infinite(),
+    pull.filter(function () {
+      throw error
+    }),
+    pull.collect(function (err) {
+      t.deepEqual(err, error)
+      t.end()
+    })
+  )
+})

--- a/throughs/filter.js
+++ b/throughs/filter.js
@@ -12,8 +12,14 @@ module.exports = function filter (test) {
         loop = false
         sync = true
         read(end, function (end, data) {
-          if(!end && !test(data))
-            return sync ? loop = true : next(end, cb)
+          try {
+            if(!end && !test(data)) {
+              return sync ? loop = true : next(end, cb)
+            }
+          } catch (err) {
+            end = err
+          }
+
           cb(end, data)
         })
         sync = false


### PR DESCRIPTION
Errors thrown by the function passed to the [filter](https://github.com/pull-stream/pull-stream/blob/master/throughs/filter.js) through are not being caught, so catch them and use them to end the stream.