### PR TITLE
Fix link to concat sink docs

### DIFF
--- a/docs/sinks/index.md
+++ b/docs/sinks/index.md
@@ -16,7 +16,7 @@ See also:
 
 ## [drain](./drain.md)
 ## [reduce](./reduce.md)
-## [concat](./collect.md)
+## [concat](./concat.md)
 ## [collect](./collect.md)
 ## [onEnd](./on-end.md)
 ## [log](./log.md)


### PR DESCRIPTION
Just a small documentation fix here: the link to the docs for concat were pointing to the docs for collect.