### PR TITLE
Simplify and defer checks in flatten to improve performance

### DIFF
--- a/benchmarks/flatten.js
+++ b/benchmarks/flatten.js
@@ -1,0 +1,38 @@
+const faker = require('faker');
+const pull = require('../');
+
+const bench = require('fastbench')
+
+faker.seed(24849320);
+function getRandomValues(nestLevel) {
+  return Array(faker.datatype.number(1000) + 1)
+  .fill(1)
+  .map(e => faker.datatype.number());
+}
+
+const N=100;
+const randomValues = Array(N)
+  .fill(1)
+  .map(e => pull.values(
+    new Array(500)
+    .fill(1)
+    .map(e => pull.values(getRandomValues()))
+  ));
+
+let i = 0;
+const run = bench([
+  function flattenBench (done) {
+    pull(
+      randomValues[i++],
+      pull.flatten(),
+      pull.drain()
+    );
+    done();
+  }]
+, N)
+
+var heap = process.memoryUsage().heapUsed
+run(function () {
+  console.log((process.memoryUsage().heapUsed - heap)/N)
+})
+

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/pull-stream/pull-stream.git"
   },
   "devDependencies": {
+    "faker": "^5.5.1",
     "fastbench": "^1.0.1",
     "pull-abortable": "~2.0.0",
     "tape": "~2.12.3"

--- a/throughs/flatten.js
+++ b/throughs/flatten.js
@@ -18,9 +18,9 @@ module.exports = function flatten () {
 
       function nextChunk () {
         _read(null, function (err, data) {
-          if (err === true) nextStream()
-          else if (err) {
-            read(true, function(abortErr) {
+          if (err) {
+            if (err === true) nextStream()
+            else read(true, function(abortErr) {
               // TODO: what do we do with the abortErr?
               cb(err)
             })
@@ -33,9 +33,9 @@ module.exports = function flatten () {
         read(null, function (end, stream) {
           if(end)
             return cb(end)
-          if(Array.isArray(stream) || stream && 'object' === typeof stream)
+          if(stream && 'object' === typeof stream)
             stream = values(stream)
-          else if('function' != typeof stream)
+          else if ('function' !== typeof stream)
             stream = once(stream)
           _read = stream
           nextChunk()

--- a/throughs/flatten.js
+++ b/throughs/flatten.js
@@ -3,24 +3,15 @@
 var values = require('../sources/values')
 var once = require('../sources/once')
 
-function getAbortCb(read, abort, cb) {
-  return function(err) {
-    read(err || abort, cb)
-  }
-}
-function getChunkErrorCb(err, cb) {
-  return function() {
-    cb(err)
-  }
-}
-
 //convert a stream of arrays or streams into just a stream.
 module.exports = function flatten () {
   return function (read) {
     var _read
     return function (abort, cb) {
       if (abort) { //abort the current stream, and then stream of streams.
-        _read ? _read(abort, getAbortCb(read, abort, cb)) : read(abort, cb)
+        _read ? _read(abort, function(err) {
+          read(err || abort, cb)
+        }) : read(abort, cb)
       }
       else if(_read) nextChunk()
       else nextStream()
@@ -29,7 +20,10 @@ module.exports = function flatten () {
         _read(null, function (err, data) {
           if (err) {
             if (err === true) nextStream()
-            else read(true, getChunkErrorCb(err, cb))
+            else read(true, function(abortErr) {
+              // TODO: what do we do with the abortErr?
+              cb(err)
+            })
           }
           else cb(null, data)
         })

--- a/throughs/flatten.js
+++ b/throughs/flatten.js
@@ -3,15 +3,24 @@
 var values = require('../sources/values')
 var once = require('../sources/once')
 
+function getAbortCb(read, abort, cb) {
+  return function(err) {
+    read(err || abort, cb)
+  }
+}
+function getChunkErrorCb(err, cb) {
+  return function() {
+    cb(err)
+  }
+}
+
 //convert a stream of arrays or streams into just a stream.
 module.exports = function flatten () {
   return function (read) {
     var _read
     return function (abort, cb) {
       if (abort) { //abort the current stream, and then stream of streams.
-        _read ? _read(abort, function(err) {
-          read(err || abort, cb)
-        }) : read(abort, cb)
+        _read ? _read(abort, getAbortCb(read, abort, cb)) : read(abort, cb)
       }
       else if(_read) nextChunk()
       else nextStream()
@@ -20,10 +29,7 @@ module.exports = function flatten () {
         _read(null, function (err, data) {
           if (err) {
             if (err === true) nextStream()
-            else read(true, function(abortErr) {
-              // TODO: what do we do with the abortErr?
-              cb(err)
-            })
+            else read(true, getChunkErrorCb(err, cb))
           }
           else cb(null, data)
         })


### PR DESCRIPTION
In my performance testing w/ [JITDB](https://github.com/ssb-ngi-pointer/jitdb), this change significantly reduced the time `flatten` spends at the top of the stack.

Please let me know if you need any changes to this PR before merging.