### PR TITLE
remove non-existing `onAbort` from documentation of count, infinite a…

### DIFF
--- a/docs/sources/count.md
+++ b/docs/sources/count.md
@@ -4,7 +4,7 @@
 
 ### `count = require('pull-stream/sources/count')`
 
-### `count(max, onAbort)`
+### `count(max)`
 
 create a stream that outputs `0 ... max`.
 by default, `max = Infinity`, see

--- a/docs/sources/infinite.md
+++ b/docs/sources/infinite.md
@@ -4,7 +4,7 @@
 
 ### `infinite = require('pull-stream/sources/infinite')`
 
-### `infinite(generator, onAbort)`
+### `infinite(generator)`
 
 create an unending stream by repeatedly calling a generator
 function (by default, `Math.random`)

--- a/docs/sources/keys.md
+++ b/docs/sources/keys.md
@@ -4,7 +4,7 @@
 
 ### `keys = require('pull-stream/sources/keys')`
 
-### `keys(array | object, onAbort)`
+### `keys(array | object)`
 
 stream the key names from an object (or array)
 


### PR DESCRIPTION
…nd keys