### PR TITLE
when drain() throws an error, provide stack trace

### DIFF
--- a/sinks/drain.js
+++ b/sinks/drain.js
@@ -3,6 +3,12 @@
 module.exports = function drain (op, done) {
   var read, abort
 
+  // Declared here so that it captures the drain's stack trace
+  var doneLackingErr
+  if (!done) {
+    doneLackingErr = new Error('no done callback supplied')
+  }
+
   function sink (_read) {
     read = _read
     if(abort) return sink.abort()
@@ -18,8 +24,10 @@ module.exports = function drain (op, done) {
             if(end = end || abort) {
               loop = false
               if(done) done(end === true ? null : end)
-              else if(end && end !== true)
+              else if(end && end !== true) {
+                console.warn(doneLackingErr)
                 throw end
+              }
             }
             else if(op && false === op(data) || abort) {
               loop = false


### PR DESCRIPTION
## Context

https://github.com/ssb-ngi-pointer/go-ssb-room/pull/201

## Problem

The `throw end` there is done inside the `next()` function which kind of runs in a vacuum, so it rarely provides any context, it just crashes and says `    ^ throw end`.

## Solution

Capture a stack trace at the point where `drain()` was called, which probably will provide more context on *where* the drain was created without a second argument.

## Extra

One thing @cryptix and I learned is that _drain without a 2nd argument considered harmful, **especially** when the source pull-stream is from a remote peer susceptible to network errors ending the stream_.