### PR TITLE
new sink collectAsPromise

### DIFF
--- a/docs/sinks/collect-as-promise.md
+++ b/docs/sinks/collect-as-promise.md
@@ -1,0 +1,19 @@
+# pull-stream/sinks/collect-as-promise
+
+## usage
+
+### `collectAsPromise = require('pull-stream/sinks/collect-as-promise')`
+
+### `collectAsPromise()`
+
+Read the stream into an array, then deliver the array in a promise.
+
+```js
+const ary = await pull(
+  pull.values([10, 20, 30]),
+  pull.collectAsPromise()
+)
+
+console.log(arg)
+// ==> [10, 20, 30]
+```

--- a/sinks/collect-as-promise.js
+++ b/sinks/collect-as-promise.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var collect = require('./collect')
+
+module.exports = function collectAsPromise() {
+  return (source) => {
+    let resolve
+    let reject
+    const promise = new Promise((res, rej) => {
+      resolve = res
+      reject = rej
+    });
+
+    collect((err, ary) => {
+      if (err) reject(err)
+      else resolve(ary)
+    })(source)
+
+    return promise
+  }
+}

--- a/sinks/index.js
+++ b/sinks/index.js
@@ -7,6 +7,7 @@ module.exports = {
   find: require('./find'),
   reduce: require('./reduce'),
   collect: require('./collect'),
+  collectAsPromise: require('./collect-as-promise'),
   concat: require('./concat')
 }
 

--- a/test/collect-as-promise.js
+++ b/test/collect-as-promise.js
@@ -1,0 +1,10 @@
+var pull = require('../')
+var test = require('tape')
+
+test('collectAsPromise on values', async (t) => {
+  const ary = await pull(
+    pull.values([10,20,30]),
+    pull.collectAsPromise()
+  )
+  t.deepEquals(ary, [10,20,30])
+})


### PR DESCRIPTION
This new sink API should simplify tests a lot more.

## Before

```js
tape('do my thing', async (t) => {
  await new Promise((resolve, reject) => {
    pull(
      pull.values([10, 20, 30]),
      pull.collect((err, ary) => {
        if (err) reject(err)
        else resolve(ary)
      })
    )
  })
})
```

## After

```js
tape('do my thing', async (t) => {
  const ary = await pull(
    pull.values([10, 20, 30]),
    pull.collectAsPromise()
  })
})
```